### PR TITLE
feat: upgrade node from v12 to v16

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -21,5 +21,5 @@ outputs:
   commit_hash: # hash of the last successful workflow run
     description: 'Last successful commit'
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'dist/index.js'


### PR DESCRIPTION
Upgrade node version to avoid the warning: 
```
Download action repository 'hikoala/last-successful-commit-action@v5' (SHA:12d6108e0df375b6ab1e040ab0672203b5b671f7)
Download action repository 'hikoala/last-successful-commit-action@v6' (SHA:246146739714945d74c4335a45cb3628a729817c)
Run ./.github/actions/get-workflow-variables
Run hikoala/last-successful-commit-action@v5
Warning: The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
```

I'll add the tag v7 after merging this PR on master

See [JIRA KL-2752](https://smile-again.atlassian.net/browse/KL-2752) for more information.
