### PR TITLE
feat: use method exportVariable instead of set-output

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -61,14 +61,14 @@ const findSuccessfulWorkflowByBranch = async (workflowId, branch) => {
         const workflowId = core.getInput('workflow_id');
 
         if (currentTag && tagPattern) {
-            return core.setOutput('commit_hash', await findSuccessfulWorkflowsByTagAndTagPattern(workflowId, currentTag, tagPattern));
+            return core.exportVariable('commit_hash', await findSuccessfulWorkflowsByTagAndTagPattern(workflowId, currentTag, tagPattern));
         }
 
         if (branch) {
-            return core.setOutput('commit_hash', await findSuccessfulWorkflowByBranch(workflowId, branch));
+            return core.exportVariable('commit_hash', await findSuccessfulWorkflowByBranch(workflowId, branch));
         }
 
-        return core.setOutput('commit_hash', '');
+        return core.exportVariable('commit_hash', '');
     } catch (e) {
         core.setFailed(e.message);
     }

--- a/index.js
+++ b/index.js
@@ -54,14 +54,14 @@ const findSuccessfulWorkflowByBranch = async (workflowId, branch) => {
         const workflowId = core.getInput('workflow_id');
 
         if (currentTag && tagPattern) {
-            return core.setOutput('commit_hash', await findSuccessfulWorkflowsByTagAndTagPattern(workflowId, currentTag, tagPattern));
+            return core.exportVariable('commit_hash', await findSuccessfulWorkflowsByTagAndTagPattern(workflowId, currentTag, tagPattern));
         }
 
         if (branch) {
-            return core.setOutput('commit_hash', await findSuccessfulWorkflowByBranch(workflowId, branch));
+            return core.exportVariable('commit_hash', await findSuccessfulWorkflowByBranch(workflowId, branch));
         }
 
-        return core.setOutput('commit_hash', '');
+        return core.exportVariable('commit_hash', '');
     } catch (e) {
         core.setFailed(e.message);
     }


### PR DESCRIPTION
We still have on github actions a [warning](https://github.com/hikoala/monorepo/actions/runs/3282855966) related to action `hikoala/last-successful-commit-action@v7`.
I removed the usage of the method `set-output`. 
I'll upgrade the version of this project from `v7` to `v8` after merging this PR.